### PR TITLE
Update failing script for mac

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -10,7 +10,7 @@ install_julia(){
     local version_trim=${version%.*}
     local tmp_download_dir="$(mktemp -d -t asdf-julia.XXX)"
 
-    if [[ "$(uname)" == "Darwin" ]]; then 
+    if [[ "$(uname)" == "Darwin" ]]; then
         # if [[ "$CI_SERVER" = "yes" ]]; then
         #     local mountpath="/Volumes/Julia";
         #     local appname="Julia.app";
@@ -18,13 +18,27 @@ install_julia(){
         #     local mountpath="/Volumes/Julia-$version";
         #     local appname="/Julia-$version_trim.app";
         # fi
-        local mountpath="/Volumes/Julia-$version";
-        local appname="/Julia-$version_trim.app";
-        local url="https://s3.amazonaws.com/julialang/bin/osx/x64/$version_trim/julia-$version-osx10.7+.dmg"
+
+        local url=$(curl -s -0 https://julialang.org/downloads/ `# look at the logins page` \
+            | grep $version `# find the requested version` \
+            | grep mac64 `# get the mac binaries` \
+            | sed -n "/href/ s/.*href=['\"]\([^'\"]*\)['\"].*/\1/gp `# parse out the url`
+        ");
+
         curl $url --create-dirs -so "$tmp_download_dir/julia.dmg"
-        hdiutil mount "$tmp_download_dir/julia.dmg"
-        cp -R "$mountpath/$appname/Contents/Resources/julia" $install_path
-        hdiutil unmount $mountpath
+
+        local volume_path=$(
+            hdiutil mount ./julia.dmg `# mount the dmg`\
+            | grep Volume `# find the volume row in the output`\
+            | egrep -o '/Volumes[^\n]+' `# store the volume's path`\
+        )
+
+        local source_path=$(find $volume_path -type d -print 2> /dev/null `# find all directories in the new volume, redirect the errors so they don't interfere with the grep` \
+            | grep 'Contents/Resources/julia$' `#find the julia directory` \
+        );
+
+        cp -R $source_path $install_path
+        hdiutil unmount $volume_path
         exit;
     fi
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
-curl -s 'https://api.github.com/repos/JuliaLang/julia/releases' | 
-python -c " 
-import sys, json
-file=json.load(sys.stdin)
-for obj in file:
-    if '-' in obj['tag_name'].strip('v'):
-        continue
-    print(obj['tag_name'].strip('v'))
-"
+curl -s -0 https://julialang.org/downloads/ `# look at the download page` \
+    | grep https://github.com/JuliaLang/julia/releases `# find all links to github releases` \
+    | grep -o "\\d\\.\\d\\.\\d" `# parse out a version number` \
+    | uniq `# display only unique versions`


### PR DESCRIPTION
The existing script has been updated so it works on mac.
The script has been updated to be less rigid and make fewer assumptions, one of the major changes is in list-all where the list of releases is downloaded and parsed from the download page (only the releases able to be downloaded, as opposed to all of them) without the python dependency.