### PR TITLE
Fix return status if error during install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 script: asdf plugin-test julia https://github.com/rkyleg/asdf-julia.git 'julia --version'
 before_script:
-  - git clone https://github.com/asdf-vm/asdf.git asdf --branch v0.4.0
+  - git clone https://github.com/asdf-vm/asdf.git asdf --branch v0.6.2
   - . asdf/asdf.sh
 env:
   - CI_SERVER=yes

--- a/bin/install
+++ b/bin/install
@@ -2,6 +2,8 @@
 
 # https://s3.amazonaws.com/julialang/bin/osx/x64/0.5/julia-0.5.0-osx10.7+.dmg
 
+set -e
+
 install_julia(){
     local install_type=$1
     local version=$2


### PR DESCRIPTION
Without this, if eg the cdn download fails, the install script still returns 0.