### PR TITLE
Fixed OSX copy to locate distribution root to install dir

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -137,13 +137,13 @@ function install_julia {
         | egrep -o '/Volumes[^\n]+' `# store the volume's path`\
       )
 
-      local source_path=$(find $volume_path -type d -print 2> /dev/null `# find all directories in the new volume, redirect the errors so they don't interfere with the grep` \
+      local source_path=$(find "$volume_path" -type d -print 2> /dev/null `# find all directories in the new volume, redirect the errors so they don't interfere with the grep` \
         | grep 'Contents/Resources/julia$' `#find the julia directory` \
         | head -n 1
       )
 
-      cp -R $source_path $install_path
-      hdiutil unmount $volume_path
+      cp -R "$source_path/" $install_path
+      hdiutil unmount "$volume_path"
     else
       local untar_list="$(tar -xvf "$tmp_download_file" -C $tmp_download_dir)"
       local untar_dir="$tmp_download_dir/$(echo $untar_list | cut -f1 -d"/" | head -n 1)"


### PR DESCRIPTION
Found that the copy command on OSX was copying the Julia distribution out of the DMG and adding an extra directory level to the install directory. So instead of having the Julia binary located at `bin/julia` it would be located at `julia/bin/julia` and the asdf shim would not be installed. This was because the source directory was not terminated in a '/' and it would copy out of the DMG with the additional `julia` directory. 

I also found by happenstance that there was a minor bug with the `$volume_path` variable where if the Julia DMG was left mounted because of an error, the second time the install script is executed `$volume_path` will have a value of `/Volumes/Julia-1.4.2 2` (note the space) and then would fail to umount the DMG. asdf would then see the exit code of the install script and fail to create the shim file. So quoting `$volume_path` and the derived `$source_path` variables fixed this problem. 