### PR TITLE
fix mac arm install url

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -14,7 +14,7 @@ function get_arch_short {
     "i686")
       local arch_short="x86"
       ;;
-    "x86_64")
+    "x86_64" | "arm64")
       local arch_short="x64"
       ;;
   esac


### PR DESCRIPTION
The url for the julia installer for mac arm architecture was wrong.
It's currently the same as the intel 64 bits.