### PR TITLE
Fix mktemp on Alpine

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -106,7 +106,7 @@ function get_url_from_nightly {
 function download_binary_archive {
   local version=$1
 
-  local tmp_download_dir="$(mktemp -d -t asdf-julia.XXX)"
+  local tmp_download_dir="$(mktemp -d -t asdf-julia.XXXXXX)"
   local tmp_download_file="$tmp_download_dir/julia.archive"
 
   if [[ $version == "nightly" ]]; then


### PR DESCRIPTION
```
$ mktemp -d -t foo.XXX
mktemp: (null): Invalid argument

$ mktemp -d -t foo.XXXXXX
/tmp/foo.kipGjP

$ cat /etc/os-release
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.14.0
PRETTY_NAME="Alpine Linux v3.14"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://bugs.alpinelinux.org/"
```

I'm guessing this is a busybox or musl thing. Also tested the update on MacOS and Ubuntu with glibc.