### PR TITLE
Fix/mktemp

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -5,8 +5,8 @@ function sort_versions() {
     LC_ALL=C sort -gt. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | sort -r - | awk '{print $2}'
 }
 
-releases=$(tempfile -s .json)
-headers=$(tempfile)
+releases=$(mktemp --suffix=.json)
+headers=$(mktemp)
 
 cmd="curl -Ls0 -D$headers"
 releases_path="https://api.github.com/repos/JuliaLang/julia/releases?page="

--- a/bin/list-all
+++ b/bin/list-all
@@ -5,7 +5,7 @@ function sort_versions() {
     LC_ALL=C sort -gt. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | sort -r - | awk '{print $2}'
 }
 
-releases=$(mktemp --suffix=.json)
+releases=$(mktemp)
 headers=$(mktemp)
 
 cmd="curl -Ls0 -D$headers"


### PR DESCRIPTION
`tempfile` is not available on non-debian-based linux distributions. Thus, `asdf-julia` is currently broken on Arch Linux and most likely macos as well. This fixes things for Arch Linux. I cannot test on macos locally.