### PR TITLE
fix: avoid "tempfile: command not found" on systems not based on Debian

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -5,8 +5,8 @@ function sort_versions() {
     LC_ALL=C sort -gt. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | sort -r - | awk '{print $2}'
 }
 
-releases=$(tempfile -s .json)
-headers=$(tempfile)
+releases=$(mktemp --suffix=".json")
+headers=$(mktemp)
 
 cmd="curl -Ls0 -D$headers"
 releases_path="https://api.github.com/repos/JuliaLang/julia/releases?page="


### PR DESCRIPTION
tempfile's manpage also says it's deprecated and to use mktemp instead