### PR TITLE
Natural sort order in `list all` command

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -2,7 +2,7 @@
 
 function sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
-    LC_ALL=C sort -gt. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | sort -r - | awk '{print $2}'
+    LC_ALL=C sort -gt. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | sort -rV - | awk '{print $2}'
 }
 
 releases=$(mktemp)

--- a/bin/list-all
+++ b/bin/list-all
@@ -2,7 +2,7 @@
 
 function sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
-    LC_ALL=C sort -gt. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | sort -rV - | awk '{print $2}'
+    LC_ALL=C sort -gt. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{arr[NR]=$0} END {for (i=NR; i>0; i--) {split(arr[i], a, " "); print a[2]}}'
 }
 
 releases=$(mktemp)


### PR DESCRIPTION
Running `asdf list all julia` currently does not list Julia versions in natural sort order. Instead, we get something like the following:

```
...
1.0.5
1.10.0-alpha1
1.10.0-beta1
1.10.0-beta2
1.10.0-beta3
1.10.0-rc1
1.10.0-rc2
1.10.0-rc3
1.10.0
1.1.0-rc1
1.1.0-rc2
1.1.0
1.1.1
...
1.9.0-rc3
1.9.0
1.9.1
1.9.2
1.9.3
1.9.4
```

This is clearly less than ideal, especially with the recent release of version 1.10, which gets buried further up into the list where most people won't initially think to look for it (like I did the other day).

This PR adds the `-V` flag to the `sort` command in the `sort_versions` function, which provides natural order version sorting. 

However, my understanding is that not all operating systems have a version of `sort` that supports that flag. Therefore, let's treat this PR as the start the process of addressing this issue. I'm sure there is an OS/version agnostic way of getting natural sort, I just don't know what it is yet. Another option is to try to use the `-V` flag and if that fails, resort to the current behavior (I don't know bash well enough to code that up yet, but I can figure it out over the weekend).