### PR TITLE
Add exec-env to setup JULIA_DIR and JULIA_HOME

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# vars figured out from this doc
+# https://julia-doc.readthedocs.io/en/latest/manual/embedding/
+if [ "${JULIA_DIR:-}" = "" ]; then
+  export JULIA_DIR="$ASDF_INSTALL_PATH"
+fi
+
+if [ "${JULIA_HOME:-}" = "" ]; then
+  export JULIA_HOME="$JULIA_DIR/bin"
+fi


### PR DESCRIPTION
I'm not sure about the values, I figured them out from [here](https://julia-doc.readthedocs.io/en/latest/manual/embedding/) - quite non-standard in comparison to `JAVA_HOME`, `CARGO_HOME`, `DOTNET_ROOT`, which point to root install path - but the script itself is pretty standart.